### PR TITLE
force annotation to default on

### DIFF
--- a/src/fenics_adjoint/__init__.py
+++ b/src/fenics_adjoint/__init__.py
@@ -55,3 +55,4 @@ __author__ = meta["Author"]
 __license__ = meta["License"]
 
 set_working_tape(Tape())
+continue_annotation()


### PR DESCRIPTION
https://github.com/dolfin-adjoint/pyadjoint/pull/113 changes the default behaviour of pyadjoint so that annotation is off by default. This is a Good Thing because having an expensive operation like annotation happen as a side effect of a module import is a footgun for users and inconvenient for library developers. However, we don't want to retrospectively change the behaviour of fenics_adjoint, so this PR imposes the old behaviour.