### PR TITLE
Add riesz representation.

### DIFF
--- a/src/fenics_adjoint/types/function.py
+++ b/src/fenics_adjoint/types/function.py
@@ -221,7 +221,7 @@ class Function(FloatingType, dolfin.Function):
                 "Unknown Riesz representation %s" % riesz_map)
         return a
     
-    def _riesz_representation(self, options=None):
+    def _ad_riesz_representation(self, options=None):
         options = {} if options is None else options
         riesz_map = options.get("riesz_map", "l2")
 


### PR DESCRIPTION
This PR is associated with the [PR 139](https://github.com/dolfin-adjoint/pyadjoint/pull/139), which creates a dual `RolVector` using the Riesz representation to make a mapping from the primal to the dual space. I created `OverloadType._ries_representation` in pyadjoint,  which leads to an error in `dolfin-adjoint`. To fix it, this PR creates the `_ries_representation` method here.