### PR TITLE
Support for near nullspace

### DIFF
--- a/src/fenics_adjoint/blocks/petsc_krylov_solver.py
+++ b/src/fenics_adjoint/blocks/petsc_krylov_solver.py
@@ -29,7 +29,6 @@ class PETScKrylovSolveBlock(SolveLinearSystemBlock):
         self.ksp_options_prefix = kwargs.pop("ksp_options_prefix")
         self._ad_nullspace = kwargs.pop("_ad_nullspace")
         self._ad_near_nullspace = kwargs.pop("_ad_near_nullspace")
-        self.comm=A.mpi_comm()
 
         if self.nonzero_initial_guess:
             # Here we store a variable that isn't necessarily a dependency.
@@ -56,11 +55,8 @@ class PETScKrylovSolveBlock(SolveLinearSystemBlock):
 
         solver = self.block_helper.adjoint_solver
         if solver is None:
-            from petsc4py import PETSc
-            ksp = PETSc.KSP().create(comm=self.comm) 
-            solver = backend.PETScKrylovSolver(ksp) # self.method,self.preconditioner,
-            #solver = dolfin.PETScKrylovSolver(self.method, self.preconditioner)
-            #solver.ksp().setOptionsPrefix(self.ksp_options_prefix)
+            solver = dolfin.PETScKrylovSolver(self.method, self.preconditioner)
+            solver.ksp().setOptionsPrefix(self.ksp_options_prefix)
             solver.set_from_options()
 
             if self.assemble_system:
@@ -118,11 +114,8 @@ class PETScKrylovSolveBlock(SolveLinearSystemBlock):
     def _forward_solve(self, lhs, rhs, func, bcs, **kwargs):
         solver = self.block_helper.forward_solver
         if solver is None:
-            from petsc4py import PETSc
-            ksp = PETSc.KSP().create(comm=self.comm) 
-            solver = backend.PETScKrylovSolver(ksp) # self.method,self.preconditioner,
-            #solver = dolfin.PETScKrylovSolver(self.method, self.preconditioner)
-            #solver.ksp().setOptionsPrefix(self.ksp_options_prefix)
+            solver = dolfin.PETScKrylovSolver(self.method, self.preconditioner)
+            solver.ksp().setOptionsPrefix(self.ksp_options_prefix)
             solver.set_from_options()
 
             if self.assemble_system:

--- a/src/fenics_adjoint/petsc_krylov_solver.py
+++ b/src/fenics_adjoint/petsc_krylov_solver.py
@@ -47,9 +47,9 @@ class PETScKrylovSolver(dolfin.PETScKrylovSolver):
         self.operator = arg0
         if hasattr(self.operator, "_ad_nullspace"):
             self._ad_nullspace = self.operator._ad_nullspace
-        self.block_helper = PETScKrylovSolveBlockHelper()
         if hasattr(self.operator, "_ad_near_nullspace"):
             self._ad_near_nullspace = self.operator._ad_near_nullspace
+
         self.block_helper = PETScKrylovSolveBlockHelper()
         return dolfin.PETScKrylovSolver.set_operator(self, arg0)
 

--- a/src/fenics_adjoint/petsc_krylov_solver.py
+++ b/src/fenics_adjoint/petsc_krylov_solver.py
@@ -39,11 +39,17 @@ class PETScKrylovSolver(dolfin.PETScKrylovSolver):
         self._ad_nullspace = None
         if hasattr(self.operator, "_ad_nullspace"):
             self._ad_nullspace = self.operator._ad_nullspace
+        self._ad_near_nullspace = None
+        if hasattr(self.operator, "_ad_near_nullspace"):
+            self._ad_near_nullspace = self.operator._ad_near_nullspace
 
     def set_operator(self, arg0):
         self.operator = arg0
         if hasattr(self.operator, "_ad_nullspace"):
             self._ad_nullspace = self.operator._ad_nullspace
+        self.block_helper = PETScKrylovSolveBlockHelper()
+        if hasattr(self.operator, "_ad_near_nullspace"):
+            self._ad_near_nullspace = self.operator._ad_near_nullspace
         self.block_helper = PETScKrylovSolveBlockHelper()
         return dolfin.PETScKrylovSolver.set_operator(self, arg0)
 
@@ -51,6 +57,8 @@ class PETScKrylovSolver(dolfin.PETScKrylovSolver):
         self.operator = arg0
         if hasattr(self.operator, "_ad_nullspace"):
             self._ad_nullspace = self.operator._ad_nullspace
+        if hasattr(self.operator, "_ad_near_nullspace"):
+            self._ad_near_nullspace = self.operator._ad_near_nullspace
 
         self.pc_operator = arg1
         self.block_helper = PETScKrylovSolveBlockHelper()
@@ -87,6 +95,7 @@ class PETScKrylovSolver(dolfin.PETScKrylovSolver):
                                           krylov_preconditioner=self.preconditioner,
                                           ksp_options_prefix=ksp_options_prefix,
                                           _ad_nullspace=self._ad_nullspace,
+                                          _ad_near_nullspace=self._ad_near_nullspace,
                                           ad_block_tag=self.ad_block_tag,
                                           **sb_kwargs)
             tape.add_block(block)

--- a/src/fenics_adjoint/types/as_backend_type.py
+++ b/src/fenics_adjoint/types/as_backend_type.py
@@ -2,15 +2,16 @@ import dolfin
 
 
 __set_nullspace = dolfin.cpp.la.PETScMatrix.set_nullspace
-
-
 def set_nullspace(self, nullspace):
     self._ad_original_ref._ad_nullspace = nullspace
     __set_nullspace(self, nullspace)
-
-
 dolfin.cpp.la.PETScMatrix.set_nullspace = set_nullspace
 
+__set_near_nullspace = dolfin.cpp.la.PETScMatrix.set_near_nullspace
+def set_near_nullspace(self, near_nullspace):
+    self._ad_original_ref._ad_near_nullspace = near_nullspace
+    __set_near_nullspace(self, near_nullspace)
+dolfin.cpp.la.PETScMatrix.set_near_nullspace = set_near_nullspace
 
 class VectorSpaceBasis(dolfin.VectorSpaceBasis):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Changed petsc_krylov_solver to pick up a near nullspace and use it if it is attached to the PETSc matrix.